### PR TITLE
FLPATH-1526: link to troubleshooting guide + configmap update

### DIFF
--- a/docs/mta/README.md
+++ b/docs/mta/README.md
@@ -31,7 +31,7 @@ while [[ $retry_count -lt 5 ]]; do
 done
 echo "https://"$(oc -n openshift-mta get route mta -o yaml | yq -r .spec.host)
 ```
-Set the value of `quarkus.rest-client.mta_json.url~` to `http://mta-ui.openshift-mta.svc.cluster.local:8080/hub`
+Set the value of `quarkus.rest-client.mta_json.url` to `http://mta-ui.openshift-mta.svc.cluster.local:8080/hub`
 
 The mtaanalysis-props configmap should be similar to this:
 ```console


### PR DESCRIPTION
Updated readme  file for MTA workflow
- Added link to the troubleshooting guide.
- Added info to update the `quarkus.rest-client.mta_json.url` field in the `mtaanalysis-props` ConfigMap
  Ran into issue where since the `mta.url` points to the external https route, the `quarkus.rest-client.mta_json.url` was still pointing 
  to ${mta.url} and it couldn't connect to it. It worked after I set `quarkus.rest-client.mta_json.url` to `http://mta-ui.openshift-mta.svc.cluster.local:8080/hub`.