### PR TITLE
FIx move2kube instance access with network policy

### DIFF
--- a/charts/move2kube/templates/00-move2kube-instance.yaml
+++ b/charts/move2kube/templates/00-move2kube-instance.yaml
@@ -1,8 +1,16 @@
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.instance.namespace }}
+spec:
+  {}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.instance.name }}
+  namespace: {{ .Values.instance.namespace }}
 spec:
   selector:
     matchLabels:
@@ -49,6 +57,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.instance.name }}-svc
+  namespace: {{ .Values.instance.namespace }}
 spec:
   ports:
     - port: 8080
@@ -60,6 +69,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ .Values.instance.name }}-route
+  namespace: {{ .Values.instance.namespace }}
 spec:
   tls:
     termination: edge

--- a/charts/move2kube/values.yaml
+++ b/charts/move2kube/values.yaml
@@ -11,3 +11,4 @@ kfunction:
 instance:
   name: move2kube # name of the move2kube instance deployment
   image: quay.io/konveyor/move2kube-ui:v0.3.14-rc.0 # image of the move2kube instance
+  namespace: move2kube


### PR DESCRIPTION
Closes [FLPATH-1592](https://issues.redhat.com/browse/FLPATH-1592)
FIx move2kube instance access from route with network policy by deploying the move2kube instance in another namespace than sonataflow-infra